### PR TITLE
Add docker restart policy for production

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,15 +1,12 @@
 version: "3.9"
 
 services:
-
   perlite:
     image: sec77/perlite:latest
     container_name: perlite-dev
-          
     environment:
       - NOTES_PATH=Demo
       - HIDE_FOLDERS=docs,private,trash
-
     volumes:
       - ./perlite:/var/www/perlite
       - ./Demo:/var/www/perlite/Demo:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   perlite:
     image: sec77/perlite:latest
     container_name: perlite
+    restart: unless-stopped
    
     environment:
       - NOTES_PATH=Demo
@@ -18,6 +19,7 @@ services:
         context: ./web
     image: sec77/perlite_web:stable
     container_name: perlite_web
+    restart: unless-stopped
     ports:
       - 80:80
     volumes_from: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,13 @@
 version: "3.9"
 
 services:
-
   perlite:
     image: sec77/perlite:latest
     container_name: perlite
     restart: unless-stopped
-   
     environment:
       - NOTES_PATH=Demo
       - HIDE_FOLDERS=docs,private,trash
-
     volumes:
       - ./Demo:/var/www/perlite/Demo:ro
 
@@ -26,6 +23,4 @@ services:
       - perlite       
     depends_on:
       - perlite
-
-  
 


### PR DESCRIPTION
Hi :wave:,

this pull request adds the docker restart policy `unless-stopped` for the stack in production. This ensures that both containers start up when your host reboots.

I also removed some whitespaces and newlines from both `docker-compose.yml` files. If you dislike the style commit let me know and I drop it. 