### PR TITLE
feat: improve blockquote styling

### DIFF
--- a/Demo/Demo Documents/markdown-sample2.md
+++ b/Demo/Demo Documents/markdown-sample2.md
@@ -54,6 +54,9 @@ Start numbering with offset:
 57. foo
 1. bar
 
+## Blockquote
+
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin id felis quis nisl gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.
 
 ## Code
 

--- a/perlite/.styles/style.css
+++ b/perlite/.styles/style.css
@@ -22,7 +22,11 @@
 
 
 blockquote {
-  margin: 1rem;
+  background: #212325;
+  border-left: 4px solid #3E4446;
+  padding: 0.5rem;
+  margin-inline-start: 30px;
+  margin-inline-end: 30px;
 }
 
 h2 {


### PR DESCRIPTION
Hi :wave:,

this pull request improves the `blockquote` styling. Let me know what you think.

Before
![blockquote_before](https://user-images.githubusercontent.com/5375334/176038787-328c114b-b2b4-4ede-b5df-5c7dabdc679f.png)
After
![blockquote_after2](https://user-images.githubusercontent.com/5375334/176258426-ff79b141-2f51-4759-b811-4936fe0feb5a.png)


