### PR TITLE
feat: support Callouts

### DIFF
--- a/Demo/Demo Documents/markdown-sample3.md
+++ b/Demo/Demo Documents/markdown-sample3.md
@@ -1,0 +1,30 @@
+
+Callout with title
+
+> [!Note] Title
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin `id felis quis nisl` gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.
+
+Callout defaults to Note
+> [!Unknown]
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin `id felis quis nisl` gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.
+
+Callout without title
+
+> [!INFO]
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin `id felis quis nisl` gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.
+
+Callout is case insensitive
+
+> [!iNfO]
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin `id felis quis nisl` gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.
+
+Callout with other color
+
+> [!bug]
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin `id felis quis nisl` gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.
+
+
+Regular blockquote
+
+> Lorem ipsum
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et gravida diam, et varius magna. Proin `id felis quis nisl` gravida auctor a eu est. In viverra dui viverra placerat cursus. Curabitur non commodo mi. Mauris volutpat nisl vitae nulla efficitur condimentum. Nulla facilisi. Maecenas malesuada purus mi, eget fringilla quam ultrices sit amet.

--- a/perlite/.styles/style.css
+++ b/perlite/.styles/style.css
@@ -23,10 +23,87 @@
 
 blockquote {
   background: #212325;
-  border-left: 4px solid #3E4446;
+  border-left: 6px solid #3E4446;
   padding: 0.5rem;
   margin-inline-start: 30px;
   margin-inline-end: 30px;
+}
+
+/*
+  Callouts
+
+  The types and colors originate from the Obsidian client. Any unrecognized type will
+  default to the "note" type.
+*/
+
+.callout {
+  --callout-color: 68, 138, 255;
+}
+
+.callout[data-callout="abstract"],
+.callout[data-callout="summary"],
+.callout[data-callout="tldr"] {
+  --callout-color: 0, 176, 255;
+}
+
+.callout[data-callout="info"],
+.callout[data-callout="todo"] {
+  --callout-color: 0, 184, 212;
+}
+
+.callout[data-callout="tip"],
+.callout[data-callout="hint"],
+.callout[data-callout="important"] {
+  --callout-color: 0, 191, 165;
+}
+
+.callout[data-callout="success"],
+.callout[data-callout="check"],
+.callout[data-callout="done"] {
+  --callout-color: 0, 200, 83;
+}
+
+.callout[data-callout="question"],
+.callout[data-callout="help"],
+.callout[data-callout="faq"] {
+  --callout-color: 100, 221, 23;
+}
+
+.callout[data-callout="warning"],
+.callout[data-callout="caution"],
+.callout[data-callout="attention"] {
+  --callout-color: 255, 145, 0;
+}
+
+.callout[data-callout="failure"],
+.callout[data-callout="fail"],
+.callout[data-callout="missing"] {
+  --callout-color: 255, 82, 82;
+}
+
+.callout[data-callout="danger"],
+.callout[data-callout="error"] {
+  --callout-color: 255, 23, 68;
+}
+
+.callout[data-callout="bug"] {
+  --callout-color: 245, 0, 87;
+}
+
+.callout[data-callout="example"] {
+  --callout-color: 124, 77, 255;
+}
+
+.callout[data-callout="quote"],
+.callout[data-callout="cite"] {
+  --callout-color: 158, 158, 158;
+}
+
+.callout {
+  border-left: 4px solid rgb(var(--callout-color));
+  border-radius: 2px;
+  margin-inline-start: unset;
+  margin-inline-end: unset;
 }
 
 h2 {

--- a/perlite/PerliteParsedown.php
+++ b/perlite/PerliteParsedown.php
@@ -1,0 +1,33 @@
+<?php
+
+include('Parsedown.php');
+
+class PerliteParsedown extends Parsedown
+{
+
+    #
+    # Callout (based on blockQuotes)
+    # See: https://help.obsidian.md/How+to/Use+callouts
+
+    protected function blockQuote($Line)
+    {
+        $quote = parent::blockQuote($Line);
+
+        if ( ! isset($quote))
+        {
+            return null;
+        }
+
+        if (preg_match('/^>\s?\[\!(.*?)\](.*?)$/m', $Line['text'], $matches))
+        {
+            $type = strtolower($matches[1]);
+            $title = $matches[2];
+
+            $quote['element']['attributes']['class'] = "callout";
+            $quote['element']['attributes']['data-callout'] = $type;
+            $quote['element']['text'][0] = $title ? : ucfirst($type);
+        }
+
+        return $quote;
+    }
+}

--- a/perlite/content.php
+++ b/perlite/content.php
@@ -57,7 +57,7 @@ function parseContent($requestFile) {
 	global $rootDir;
 	global $startDir;
 	//$Parsedown = new ParsedownExtra();
-	$Parsedown = new Parsedown();
+	$Parsedown = new PerliteParsedown();
 	$Parsedown->setSafeMode(true);
 	$Parsedown->setBreaksEnabled(true);
 	$cleanFile = '';

--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -6,7 +6,7 @@
   * Licensed under MIT (https://github.com/secure-77/Perlite/blob/main/LICENSE)
 */
 
-include('Parsedown.php');
+include('PerliteParsedown.php');
 //include('ParsedownExtra.php');
 
 


### PR DESCRIPTION
Hi :wave:,

this pull request adds support for callouts. I designed them as regular blockquote elements with a custom `callout` class attached. The implementation basically follows their documentation examples [here](https://github.com/erusev/parsedown/wiki/Tutorial:-Create-Extensions).

The callout title is optional as described in the Obsidian [documentation](https://help.obsidian.md/How+to/Use+callouts). 

~~This pull request contains the changes made in #25. So, I suggest to merge #25 first and I will rebase this branch then.~~ (:heavy_check_mark:)

Note, parsedown does not identify two blocks when the callouts or regular blockquotes are just separated by a newline. They solved this problem in the up-coming version 2 (see https://github.com/erusev/parsedown/issues/707).  I tested their beta release and can tell that the problem is gone (see #27).

Let me know what you think.

refs #20

![image](https://user-images.githubusercontent.com/5375334/176258873-5f03c1d6-5310-4d5e-8635-9dd56bf24728.png)


