### PR TITLE
PHP error fix

### DIFF
--- a/perlite/content.php
+++ b/perlite/content.php
@@ -171,14 +171,16 @@ function translateLink($pattern, $content, $path, $sameFolder) {
 
 		# replace amp back to & (comming from parsedown)
 		$urlPath = str_replace('&amp;' , '&', $urlPath);
-	
 		$urlPath = rawurlencode($urlPath);
-		if (strlen($refName) > 0) {
-			$refName = '#'.$refName;
-		}
 
-	
-		return '<a class="internal-link'.$popupClass.'" href="?link='.$urlPath.$refName.'">'. $linkName .'</a>'.$popUpIcon;
+		if (!empty($refName)) {
+			$refName = '#'.$refName;
+			return '<a class="internal-link'.$popupClass.'" href="?link='.$urlPath.$refName.'">'. $linkName .'</a>'.$popUpIcon;
+
+		} else {
+			return '<a class="internal-link'.$popupClass.'" href="?link='.$urlPath.'">'. $linkName .'</a>'.$popUpIcon;
+		}
+		
 	}
 ,$content);
 }


### PR DESCRIPTION
There is no check for if `$refName` does not exist
because of that php sometimes gives error likes that `Undefined variable $refName`

I added exist or not statment also deleted strlen() because it is not needed