### PR TITLE
Allow customizable allowed file link types

### DIFF
--- a/perlite/content.php
+++ b/perlite/content.php
@@ -57,6 +57,7 @@ function parseContent($requestFile) {
 	global $rootDir;
 	global $startDir;
 	global $lineBreaks;
+	global $allowedFileLinkTypes;
 
 
 	//$Parsedown = new ParsedownExtra();
@@ -83,15 +84,16 @@ function parseContent($requestFile) {
 	$mdpath = $path;
 	$path = $startDir . $path;
 
+	$linkFileTypes = implode( '|', $allowedFileLinkTypes);
 
 	// pdf links with Alias
 	$replaces = '<a class="internal-link" target="_blank" rel="noopener noreferrer" href="'.$path .'/'.'\\2">\\3</a>';
-	$pattern = array('/(\!?\[\[)(.*?.pdf)\|(.*)(\]\])/');
+	$pattern = array('/(\!?\[\[)(.*?.(?:' . $linkFileTypes . '))\|(.*)(\]\])/');
 	$content = preg_replace($pattern, $replaces ,$content);
 	
 	// pdf links without Alias
 	$replaces = '<a class="internal-link" target="_blank" rel="noopener noreferrer" href="'.$path .'/'.'\\2">\\2</a>';
-	$pattern = array('/(\!?\[\[)(.*?.pdf)(\]\])/');
+	$pattern = array('/(\!?\[\[)(.*?.(?:' . $linkFileTypes . '))(\]\])/');
 	$content = preg_replace($pattern, $replaces ,$content);
 
 	// img links

--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -35,7 +35,7 @@ if (empty($lineBreaks)) {
 $allowedFileLinkTypes = getenv('ALLOWED_FILE_LINK_TYPES');
 
 if (!$allowedFileLinkTypes) {
-	$allowedFileLinkTypes = ['pdf', 'docx', 'xlsx', 'pptx'];
+	$allowedFileLinkTypes = ['pdf'];
 } else {
 	$allowedFileLinkTypes = explode(",", $allowedFileLinkTypes);
 }

--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -32,6 +32,14 @@ if (empty($lineBreaks)) {
 	$lineBreaks = filter_var($lineBreaks, FILTER_VALIDATE_BOOLEAN);
 }
 
+$allowedFileLinkTypes = getenv('ALLOWED_FILE_LINK_TYPES');
+
+if (!$allowedFileLinkTypes) {
+	$allowedFileLinkTypes = ['pdf', 'docx', 'xlsx', 'pptx'];
+} else {
+	$allowedFileLinkTypes = explode(",", $allowedFileLinkTypes);
+}
+
 $about = '.about';
 $index = 'README';
 


### PR DESCRIPTION
This fixes #69 .
By default, the current behaviour is preserved, i.e. only PDF links have a special treatment. But the user can supply a comma separated list of file extensions via the `ALLOWED_FILE_LINK_TYPES` environment variable to allow special handling of more file types.