### PR TITLE
added ability to check if link between nodes already exits for global graph

### DIFF
--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -400,8 +400,22 @@ function getfullGraph($rootDir)
 							if (strcmp($elementTitle, $source) == 0) {
 								$sourceId = $element['id'];
 							}
+							$edgeExists = false;
+
+							foreach ($graphEdges as $edge) {
+								if ($edge['from'] === $sourceId && $edge['to'] === $targetId) {
+									$edgeExists = true;
+									break;
+								}
+								if ($edge['to'] === $sourceId && $edge['from'] === $targetId) {
+									$edgeExists = true;
+									break;
+								}
+							}
 							if ($targetId !== -1 && $sourceId !== -1) {
-								array_push($graphEdges, ['from' => $sourceId, 'to' => $targetId]);
+								if (!edgeExists) {
+									array_push($graphEdges, ['from' => $sourceId, 'to' => $targetId]);
+								}
 								$targetId = -1;
 								$sourceId = -1;
 							}

--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -413,7 +413,7 @@ function getfullGraph($rootDir)
 								}
 							}
 							if ($targetId !== -1 && $sourceId !== -1) {
-								if (!edgeExists) {
+								if (!$edgeExists) {
 									array_push($graphEdges, ['from' => $sourceId, 'to' => $targetId]);
 								}
 								$targetId = -1;


### PR DESCRIPTION
This closes #45

This change checks for if the link pair already exists in the edges array. I would like a faster method but this gets the job done. I was half tempted to make an array just to check against per node but that would not have helped on the backlinks check. Willing to try other things if you suggest it