### PR TITLE
Reduce getenv calls, refactor checkArray readability

### DIFF
--- a/perlite/.src/Env.php
+++ b/perlite/.src/Env.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Perlite;
+
+/**
+ * Responsible for reading environment variables
+ */
+class Env
+{
+    /**
+     * Return the value of an environment variable. undefined returns $default
+     * @param string $key
+     * @param mixed|null $default
+     * @return mixed
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        $value = getenv($key);
+        return ($value === false) ? $default : $value;
+    }
+
+    /**
+     * Return the value of a bool-style environment variable. undefined or invalid bool value returns $default
+     * ref: https://www.php.net/manual/en/function.filter-var.php#121263
+     * @param string $key
+     * @param bool $default
+     * @return bool
+     */
+    public static function getBool(string $key, bool $default = false): bool
+    {
+        return filter_var(self::get($key) ?? $default, FILTER_VALIDATE_BOOLEAN) ?? $default;
+    }
+}

--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -8,30 +8,29 @@
 
 use Perlite\PerliteParsedown;
 
-
+/** @var string[] $avFiles available file paths. paths start with "/" */
 $avFiles = array();
 
-// replace with your Vault Folder
-$rootDir = empty(getenv('NOTES_PATH')) ? 'Demo' : getenv('NOTES_PATH');
+/** @var string $rootDir replace with your Vault Folder */
+$rootDir = getenv('NOTES_PATH') ?: 'Demo';
 
 // replace with your Vault Name
 $vaultName = $rootDir;
 
 // default settings and variables
-$hideFolders = getenv('HIDE_FOLDERS');
 
 
 // Meta Tags infos
-$siteTitle = empty(getenv('SITE_TITLE')) ? 'Perlite' : getenv('SITE_TITLE');
-$siteType = empty(getenv('SITE_TYPE')) ? 'article' : getenv('SITE_TYPE');
-$siteImage = empty(getenv('SITE_IMAGE')) ? 'https://raw.githubusercontent.com/secure-77/Perlite/main/screenshots/screenshot.png' : getenv('SITE_IMAGE');
-$siteURL = empty(getenv('SITE_URL')) ? 'https://perlite.secure77.de' : getenv('SITE_URL');
-$siteDescription = empty(getenv('SITE_DESC')) ?  'A web based markdown viewer optimized for Obsidian Notes' : getenv('SITE_DESC');
-$siteName = empty(getenv('SITE_NAME')) ? 'Perlite Demo' : getenv('SITE_NAME');
-$siteTwitter = empty(getenv('SITE_TWITTER')) ? '@secure_sec77' : getenv('SITE_TWITTER');
+$siteTitle = getenv('SITE_TITLE') ?: 'Perlite';
+$siteType = getenv('SITE_TYPE') ?: 'article';
+$siteImage = getenv('SITE_IMAGE') ?: 'https://raw.githubusercontent.com/secure-77/Perlite/main/screenshots/screenshot.png';
+$siteURL = getenv('SITE_URL') ?: 'https://perlite.secure77.de';
+$siteDescription = getenv('SITE_DESC') ?: 'A web based markdown viewer optimized for Obsidian Notes';
+$siteName = getenv('SITE_NAME') ?: 'Perlite Demo';
+$siteTwitter = getenv('SITE_TWITTER') ?: '@secure_sec77';
 
 // Temp PATH for graph linking temp files
-$tempPath = empty(getenv('TEMP_PATH')) ? sys_get_temp_dir() : getenv('TEMP_PATH');
+$tempPath = getenv('TEMP_PATH') ?: sys_get_temp_dir();
 
 // line breaks
 $lineBreaks = empty(getenv('LINE_BREAKS')) ? true : filter_var(getenv('LINE_BREAKS'), FILTER_VALIDATE_BOOLEAN);
@@ -40,16 +39,16 @@ $lineBreaks = empty(getenv('LINE_BREAKS')) ? true : filter_var(getenv('LINE_BREA
 $allowedFileLinkTypes = empty(getenv('ALLOWED_FILE_LINK_TYPES')) ? ['pdf'] : explode(",",getenv('ALLOWED_FILE_LINK_TYPES'));
 
 // disable PopHovers
-$disablePopHovers = empty(getenv('DISABLE_POP_HOVER')) ? "false" : getenv('DISABLE_POP_HOVER');
+$disablePopHovers = getenv('DISABLE_POP_HOVER') ?: "false";
 
 // show TOC instead of graph
-$showTOC = empty(getenv('SHOW_TOC')) ? "false" : getenv('SHOW_TOC');
+$showTOC = getenv('SHOW_TOC') ?: "false";
 
 // Set home page from environment variable
-$index = empty(getenv('HOME_FILE')) ? "README" : getenv('HOME_FILE');
+$index = getenv('HOME_FILE') ?: "README";
 
 // set default font size
-$font_size = empty(getenv('FONT_SIZE')) ? "15" : getenv('FONT_SIZE');
+$font_size = getenv('FONT_SIZE') ?: "15";
 
 // Set safe mode from environment variable
 $htmlSafeMode = empty(getenv('HTML_SAFE_MODE')) ? true : filter_var(getenv('HTML_SAFE_MODE'), FILTER_VALIDATE_BOOLEAN);
@@ -68,12 +67,7 @@ array_push($avFiles, $indexpath);
 
 
 // hide folders
-if (strcmp($hideFolders, '')) {
-
-	$hideFolders = explode(',', $hideFolders);
-} else {
-	$hideFolders = array();
-}
+$hideFolders = explode(',', getenv('HIDE_FOLDERS') ?: '');
 
 // path management
 if (!strcmp($rootDir, "")) {
@@ -143,8 +137,8 @@ function menu($dir, $folder = '')
 			$mdFile = getFileInfos($file)[1];
 
 			$path = '/' . $path;
-			// push the the path to the array
-			array_push($avFiles, $path);
+			// add the path to the available files
+			$avFiles[] = $path;
 
 			// URL Encode the Path for the JS call
 			$pathClean = rawurlencode($path);
@@ -486,18 +480,15 @@ function removeExtension($path)
 	return substr($path, 0, -3);
 }
 
-// check if node is in array
-function checkArray($requestNode)
+/**
+ * check if node is in available files
+ * @param string $requestNode
+ * @return bool
+ */
+function checkArray(string $requestNode): bool
 {
-	global $avFiles;
-	$requestNode = '/' . $requestNode;
-
-	if (in_array($requestNode, $avFiles, true)) {
-
-		return true;
-	}
-
-	return false;
+    global $avFiles;
+    return in_array('/' . $requestNode, $avFiles, true);
 }
 
 

--- a/perlite/helper.php
+++ b/perlite/helper.php
@@ -6,13 +6,14 @@
   * Licensed under MIT (https://github.com/secure-77/Perlite/blob/main/LICENSE)
 */
 
+use Perlite\Env;
 use Perlite\PerliteParsedown;
 
 /** @var string[] $avFiles available file paths. paths start with "/" */
-$avFiles = array();
+$avFiles = [];
 
 /** @var string $rootDir replace with your Vault Folder */
-$rootDir = getenv('NOTES_PATH') ?: 'Demo';
+$rootDir = Env::get('NOTES_PATH', 'Demo');
 
 // replace with your Vault Name
 $vaultName = $rootDir;
@@ -21,53 +22,48 @@ $vaultName = $rootDir;
 
 
 // Meta Tags infos
-$siteTitle = getenv('SITE_TITLE') ?: 'Perlite';
-$siteType = getenv('SITE_TYPE') ?: 'article';
-$siteImage = getenv('SITE_IMAGE') ?: 'https://raw.githubusercontent.com/secure-77/Perlite/main/screenshots/screenshot.png';
-$siteURL = getenv('SITE_URL') ?: 'https://perlite.secure77.de';
-$siteDescription = getenv('SITE_DESC') ?: 'A web based markdown viewer optimized for Obsidian Notes';
-$siteName = getenv('SITE_NAME') ?: 'Perlite Demo';
-$siteTwitter = getenv('SITE_TWITTER') ?: '@secure_sec77';
+$siteTitle = Env::get('SITE_TITLE', 'Perlite');
+$siteType = Env::get('SITE_TYPE', 'article');
+$siteImage = Env::get('SITE_IMAGE', 'https://raw.githubusercontent.com/secure-77/Perlite/main/screenshots/screenshot.png');
+$siteURL = Env::get('SITE_URL', 'https://perlite.secure77.de');
+$siteDescription = Env::get('SITE_DESC', 'A web based markdown viewer optimized for Obsidian Notes');
+$siteName = Env::get('SITE_NAME', 'Perlite Demo');
+$siteTwitter = Env::get('SITE_TWITTER', '@secure_sec77');
 
 // Temp PATH for graph linking temp files
-$tempPath = getenv('TEMP_PATH') ?: sys_get_temp_dir();
+$tempPath = Env::get('TEMP_PATH', sys_get_temp_dir());
 
-// line breaks
-$lineBreaks = empty(getenv('LINE_BREAKS')) ? true : filter_var(getenv('LINE_BREAKS'), FILTER_VALIDATE_BOOLEAN);
+// whether to display "\n" as new line.
+$lineBreaks = Env::getBool('LINE_BREAKS', true);
 
 // file types
-$allowedFileLinkTypes = empty(getenv('ALLOWED_FILE_LINK_TYPES')) ? ['pdf'] : explode(",",getenv('ALLOWED_FILE_LINK_TYPES'));
+$allowedFileLinkTypes = explode(",", Env::get('ALLOWED_FILE_LINK_TYPES', 'pdf'));
 
 // disable PopHovers
-$disablePopHovers = getenv('DISABLE_POP_HOVER') ?: "false";
+$disablePopHovers = Env::get('DISABLE_POP_HOVER', "false");
 
 // show TOC instead of graph
-$showTOC = getenv('SHOW_TOC') ?: "false";
+$showTOC = Env::get('SHOW_TOC', "false");
 
 // Set home page from environment variable
-$index = getenv('HOME_FILE') ?: "README";
+$index = Env::get('HOME_FILE', "README");
 
 // set default font size
-$font_size = getenv('FONT_SIZE') ?: "15";
+$font_size = Env::get('FONT_SIZE', "15");
 
 // Set safe mode from environment variable
-$htmlSafeMode = empty(getenv('HTML_SAFE_MODE')) ? true : filter_var(getenv('HTML_SAFE_MODE'), FILTER_VALIDATE_BOOLEAN);
+$htmlSafeMode = Env::getBool('HTML_SAFE_MODE', true);
 
 
 $about = '.about';
 
 // add about and index to allowed files
-$aboutpath = getFileInfos($rootDir . '/' . $about)[0];
-$indexpath = getFileInfos($rootDir . '/' . $index)[0];
-$aboutpath = '/' . $aboutpath;
-$indexpath = '/' . $indexpath;
-array_push($avFiles, $aboutpath);
-array_push($avFiles, $indexpath);
-
+$avFiles[] = '/' . getFileInfos($rootDir . '/' . $about)[0];
+$avFiles[] = '/' . getFileInfos($rootDir . '/' . $index)[0];
 
 
 // hide folders
-$hideFolders = explode(',', getenv('HIDE_FOLDERS') ?: '');
+$hideFolders = explode(',', Env::get('HIDE_FOLDERS', ''));
 
 // path management
 if (!strcmp($rootDir, "")) {


### PR DESCRIPTION
While reading the code, I refactored the beginning part of the `helper.php`, mostly for readability.
I found that the Docker uses [PHP 8.2](https://hub.docker.com/layers/sec77/perlite/latest/images/sha256-bf9b8b687c8b9c9398a80dcc796789b4e3d25aabe7e10886a39cf7ea2807dc33?context=explore), and JavaScript uses [ES6](https://github.com/secure-77/Perlite/blob/main/perlite/.js/perlite.js#L256).
My editions are based on these version constraint findings.

Changes are:

1. Reduced the number of `getenv` calls by using new `Env` class, which wraps `getenv` to handle undefined keys better.
    - please note that initializers for `$hideFolders`, `$allowedFileLinkTypes` has been refactored, but maybe `trim` is needed to deal with redundant spaces.
3. Refactored `checkArray` function.
4. Updated some comments.
