### PR TITLE
FIX: Correct use of katex in double dollars $$

### DIFF
--- a/perlite/.src/PerliteParsedown.php
+++ b/perlite/.src/PerliteParsedown.php
@@ -501,27 +501,24 @@ class PerliteParsedown extends Parsedown
     # handle katex code
     protected function inlineKatex($Excerpt)
     {
-        $katex = $Excerpt['text'];
+        $marker = $Excerpt['text'][0];
+        if (preg_match('/^(\\'.$marker.'+)[ ]*(.+?)[ ]*(?<!\\'.$marker.')\1(?!\\'.$marker.')/s', $Excerpt['text'], $matches))
+        {
+            $text = $matches[0];
+            $text = preg_replace("/[ ]*\n/", ' ', $text);
 
-        if (preg_match("/(\\$\\$[^ ].*?\\$\\$)/", $Excerpt['text'], $matches)) {
-
-            $katex = $matches[0];
-
-        } else if (preg_match("/(\\$[^ ].*?\\$)/", $Excerpt['text'], $matches)) {
-
-            $katex = $matches[0];
-
-        } else {
-            return;
+            $name = 'katex';
+            if ($matches[1] === '$') {
+                $name = 'katex-inline';
+            }
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => $name,
+                    'text' => $text,
+                ),
+            );
         }
-
-        return array(
-            'extent' => strlen($katex),
-            'element' => array(
-                'name' => 'katex',
-                'text' => $katex,
-            ),
-        );
     }
 
     # handle obsidian tags


### PR DESCRIPTION
Was before update:
![Без названия (1)](https://github.com/user-attachments/assets/324ad2ea-f2b5-4937-9f73-f9c12503553a)

Became after update:
![Без названия](https://github.com/user-attachments/assets/45d5cc81-2cd6-4c00-8c8e-4b455ba2b0fe)

Test code:
```md
> [!definition]+ Определение бинарной операции
> Рассмотрим непустые множества $A$, $B$ и $C$. Тогда бинарной операцией $f$ называют отображение из множества $A\times C$ в множество $A$ или $B$.
> $$f\colon D\subseteq A \times C \to \left[ \begin{array}{lcl} A \\ B \end{array} \right.$$
```
