### PR TITLE
Support Zettelkasten Filenames

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - NOTES_PATH=Demo
       - HIDE_FOLDERS=docs,private,trash
+      - ZETTELKASTEN_FILENAMES_ENABLED=false
       - HIDDEN_FILE_ACCESS=false
       - LINE_BREAKS=true
       - ABSOLUTE_PATHS=false

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - NOTES_PATH=Demo
       - HIDE_FOLDERS=docs,private,trash
+      - ZETTELKASTEN_FILENAMES_ENABLED=false
       - HIDDEN_FILE_ACCESS=false
       - LINE_BREAKS=true
       - ABSOLUTE_PATHS=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - NOTES_PATH=Demo
       - HIDE_FOLDERS=docs,private,trash
+      - ZETTELKASTEN_FILENAMES_ENABLED=false
       - HIDDEN_FILE_ACCESS=false
       - LINE_BREAKS=true
       - ABSOLUTE_PATHS=false


### PR DESCRIPTION
### Description:

This PR adds a feature to improve how note titles are displayed in the Perlite file explorer. It introduces an optional setting that allows Perlite to use a note's frontmatter `title` field or its first H1 heading as the display title, falling back to the filename only if neither is present.

### Problem Solved (Why):

Users employing Zettelkasten or similar systems often prefix filenames with UIDs (e.g., 202305151000_actual_note_title.md). While useful for organization, these UIDs can make the file explorer view feel cluttered. This feature provides a cleaner, more readable experience, allowing Perlite to align with title display behavior in some plugins used in Obsidian and Neovim.

### Changes Implemented (How):

- A new environment variable is introduced to control this title display behavior.
- A new function has been added to helper.php responsible for resolving the preferred display title according to the new logic.
- The existing menu function in helper.php has been refactored to incorporate this new title resolution when the feature is enabled.