### PR TITLE
Fix: replace deprecated utf8_decode() with mb_strlen() and null coalescing for PHP 8.2

### DIFF
--- a/perlite/.src/PerliteParsedown.php
+++ b/perlite/.src/PerliteParsedown.php
@@ -1020,7 +1020,7 @@ class PerliteParsedown extends Parsedown
                 unset($parts[0]);
 
                 foreach ($parts as $part) {
-                    $shortage = 4 - strlen(utf8_decode($input)) % 4;
+		    $shortage = 4 - (mb_strlen($input ?? '', 'UTF-8') % 4);
 
                     $line .= str_repeat(' ', $shortage);
                     $line .= $part;


### PR DESCRIPTION
This PR replaces the deprecated usage of `utf8_decode()` with a PHP 8.2+ compatible approach using `mb_strlen()` and null coalescing operator for better readability and null handling.

**Problem:**
With the current `Dockerfile` (`FROM php:fpm-alpine`), the container installs PHP 8.2 by default. Running the app produces deprecation warnings:

```
PHP 8.2: utf8_encode() and utf8_decode() functions are deprecated
```

**Change:**
Before:

```php
$shortage = 4 - strlen(utf8_decode($input)) % 4;
```

After:

```php
$shortage = 4 - (mb_strlen($input ?? '', 'UTF-8') % 4);
```

**Benefit:**

* Removes deprecation warnings on PHP 8.2+
* Ensures forward compatibility with future PHP versions
